### PR TITLE
fix: new import for pymupdf

### DIFF
--- a/paperglobe/write_pdf.py
+++ b/paperglobe/write_pdf.py
@@ -3,7 +3,7 @@
 import math
 import os
 
-from fitz import fitz
+from pymupdf import pymupdf
 
 from paperglobe.config import PRINT_SIZES
 
@@ -32,7 +32,7 @@ def write_pdf(stripes, print_size, out_path):
         os.path.dirname(__file__), f"assets/template-{print_size}.pdf"
     )
 
-    pdf = fitz.open(pdf_path)
+    pdf = pymupdf.open(pdf_path)
 
     for index, stripe in enumerate(stripes):
         stripe.transform_colorspace("cmyk")
@@ -54,7 +54,7 @@ def write_pdf(stripes, print_size, out_path):
             },
         }
 
-        rect = fitz.Rect(
+        rect = pymupdf.Rect(
             positions[print_size]["x"][index % 2] - stripe_half_width,
             positions[print_size]["y"],
             positions[print_size]["x"][index % 2] + stripe_half_width,


### PR DESCRIPTION
From pymupdf [doc](https://pymupdf.readthedocs.io/en/latest/tutorial.html#note-on-the-name-fitz):

> Note on the Name fitz
> Old versions of PyMuPDF had their Python import name as fitz. Newer versions use pymupdf instead, and offer fitz as a fallback so that old code will still work.
> 
> The reason for the name fitz is a historical curiosity:
> 
> The original rendering library for MuPDF was called Libart.
> 
> “After Artifex Software acquired the MuPDF project, the development focus shifted on writing a new modern graphics library called “Fitz”. Fitz was originally intended as an R&D project to replace the aging Ghostscript graphics library, but has instead become the rendering engine powering MuPDF.” (Quoted from [Wikipedia](https://en.wikipedia.org/wiki/MuPDF)).
> 
> Note
> 
> Importing PyMuPDF as fitz still works however PyMuPDF cannot coexist with other packages named “fitz” in the same Python environment.


However in practice on my mac, importing fitz causes an error, which this change fixes.